### PR TITLE
[KAN-24] 종목수정및물타기

### DIFF
--- a/InvestMate/Projects/Domain/Sources/Entities/StockInfo.swift
+++ b/InvestMate/Projects/Domain/Sources/Entities/StockInfo.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct StockInfo: Equatable {
     
-    public let averagePrice: Double?
-    public let quantity: Double?
-    public let totalPrice: Double?
+    public var averagePrice: Double?
+    public var quantity: Double?
+    public var totalPrice: Double?
     
     public init(averagePrice: Double? = nil, quantity: Double? = nil, totalPrice: Double? = nil) {
         self.averagePrice = averagePrice

--- a/InvestMate/Projects/Presentation/Sources/Utils/Extensions/Preview/UIViewController+Preview.swift
+++ b/InvestMate/Projects/Presentation/Sources/Utils/Extensions/Preview/UIViewController+Preview.swift
@@ -1,5 +1,5 @@
 //
-//  UIViewController+.swift
+//  UIViewController+Preview+.swift
 //  InvestMate
 //
 //  Created by 조호근 on 10/7/24.
@@ -24,5 +24,6 @@ extension UIViewController {
     func toPreview() -> some View {
         Preview(viewController: self)
     }
+    
 }
 #endif

--- a/InvestMate/Projects/Presentation/Sources/Utils/Extensions/UIViewController+.swift
+++ b/InvestMate/Projects/Presentation/Sources/Utils/Extensions/UIViewController+.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+.swift
+//  Presentation
+//
+//  Created by 조호근 on 1/28/25.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
+}

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
@@ -15,6 +15,7 @@ public final class AdditionalPurchaseReactor: Reactor {
     public enum Action {
         case updateBoth(holdingPrice: Double?, holdingQuantity: Double?,
                         additionalPrice: Double?, additionalQuantity: Double?)
+        case setInitialStock(Stock)
     }
     
     public enum Mutation {
@@ -86,6 +87,21 @@ public final class AdditionalPurchaseReactor: Reactor {
                     final: nil
                 ))
             }
+            
+        case let .setInitialStock(stock):
+            let holding = StockInfo(
+                averagePrice: stock.averagePrice,
+                quantity: stock.quantity,
+                totalPrice: stock.totalPrice
+            )
+            
+            return .just(
+                .updateValues(
+                    holding: holding,
+                    additional: StockInfo(),
+                    final: nil
+                )
+            )
         }
     }
     

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
@@ -13,13 +13,24 @@ import RxSwift
 public final class AdditionalPurchaseReactor: Reactor {
     
     public enum Action {
-        case updateBoth(holdingPrice: Double?, holdingQuantity: Double?,
-                        additionalPrice: Double?, additionalQuantity: Double?)
+        // 현재 보유 입력 관련
+        case updateHoldingPrice(Double?)
+        case updateHoldingQuantity(Double?)
+        case updateHoldingTotal(Double?)
+        
+        // 추가 매수 입력 관련
+        case updateAdditionalPrice(Double?)
+        case updateAdditionalQuantity(Double?)
+        case updateAdditionalTotal(Double?)
+        
         case setInitialStock(Stock)
     }
     
     public enum Mutation {
-        case updateValues(holding: StockInfo, additional: StockInfo, final: StockInfo?)
+        case updateHolding(StockInfo)
+        case updateAdditional(StockInfo)
+        case updateFinal(StockInfo?)
+        case resetAdditional
     }
     
     public struct State {
@@ -42,51 +53,181 @@ public final class AdditionalPurchaseReactor: Reactor {
     
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case let .updateBoth(holdingPrice, holdingQuantity, additionalPrice, additionalQuantity):
+        case let .updateHoldingPrice(price):
+            var holding = currentState.holding
+            holding.averagePrice = price
             
-            // 1. 보유 주식 정보 생성
-            let holding = StockInfo(
-                averagePrice: holdingPrice,
-                quantity: holdingQuantity,
-                totalPrice: holdingPrice != nil && holdingQuantity != nil ?
-                holdingPrice! * holdingQuantity! : nil
-            )
-            
-            // 2. 추가 매수 정보 생성
-            let additional = StockInfo(
-                averagePrice: additionalPrice,
-                quantity: additionalQuantity,
-                totalPrice: additionalPrice != nil && additionalQuantity != nil ?
-                additionalPrice! * additionalQuantity! : nil
-            )
-            
-            // 3. 보유와 추가 정보가 모두 유효할 때 실행
-            if let hp = holdingPrice, let hq = holdingQuantity,
-               let ap = additionalPrice, let aq = additionalQuantity {
-                return calculator.calculateFinal(
-                    holdingAveragePrice: hp,
-                    holdingQuantity: hq,
-                    additionalAveragePrice: ap,
-                    additionalQuantity: aq
-                )
-                .map { finalResult in
-                        .updateValues(
-                            holding: holding,
-                            additional: additional,
-                            final: StockInfo(
-                                averagePrice: finalResult.averagePrice,
-                                quantity: finalResult.quantity,
-                                totalPrice: finalResult.totalPrice
-                            )
-                        )
-                }
-            } else {
-                return .just(.updateValues(
-                    holding: holding,
-                    additional: additional,
-                    final: nil
-                ))
+            // 평단가가 nil이면 모든 값 초기화
+            if price == nil {
+                holding.quantity = nil
+                holding.totalPrice = nil
+                return .concat([
+                    .just(.updateHolding(holding)),
+                    .just(.resetAdditional)
+                ])
             }
+            
+            // 평단가가 입력되고 수량이 있으면 총액 계산
+            if let p = price, let q = holding.quantity {
+                return calculator.calculateTotalPrice(averagePrice: p, quantity: q)
+                    .flatMap { total -> Observable<Mutation> in
+                        holding.totalPrice = total
+                        return .concat([
+                            .just(.updateHolding(holding)),
+                            .just(.resetAdditional)
+                        ])
+                    }
+            }
+            // 평단가가 입력되고 총액이 있으면 수량 계산
+            else if let p = price, let t = holding.totalPrice {
+                return calculator.calculateQuantity(averagePrice: p, totalPrice: t)
+                    .flatMap { quantity -> Observable<Mutation> in
+                        holding.quantity = quantity
+                        return .concat([
+                            .just(.updateHolding(holding)),
+                            .just(.resetAdditional)
+                        ])
+                    }
+            }
+            
+            return .concat([
+                .just(.updateHolding(holding)),
+                .just(.resetAdditional)
+            ])
+            
+        case let .updateHoldingQuantity(quantity):
+            var holding = currentState.holding
+            holding.quantity = quantity
+            
+            // 수량이 nil이면 총액도 초기화
+            if quantity == nil {
+                holding.totalPrice = nil
+                return .concat([
+                    .just(.updateHolding(holding)),
+                    .just(.resetAdditional)
+                ])
+            }
+            
+            // 수량이 입력되고 평단가가 있으면 총액 계산
+            if let p = holding.averagePrice, let q = quantity {
+                return calculator.calculateTotalPrice(averagePrice: p, quantity: q)
+                    .flatMap { total -> Observable<Mutation> in
+                        holding.totalPrice = total
+                        return .concat([
+                            .just(.updateHolding(holding)),
+                            .just(.resetAdditional)
+                        ])
+                    }
+            }
+            
+            return .concat([
+                .just(.updateHolding(holding)),
+                .just(.resetAdditional)
+            ])
+            
+        case let .updateHoldingTotal(total):
+            var holding = currentState.holding
+            holding.totalPrice = total
+            
+            // 총액이 nil이면 수량도 초기화
+            if total == nil {
+                holding.quantity = nil
+                return .concat([
+                    .just(.updateHolding(holding)),
+                    .just(.resetAdditional)
+                ])
+            }
+            
+            // 총액이 입력되고 평단가가 있으면 수량 계산
+            if let t = total, let p = holding.averagePrice {
+                return calculator.calculateQuantity(averagePrice: p, totalPrice: t)
+                    .flatMap { quantity -> Observable<Mutation> in
+                        holding.quantity = quantity
+                        return .concat([
+                            .just(.updateHolding(holding)),
+                            .just(.resetAdditional)
+                        ])
+                    }
+            }
+            
+            return .concat([
+                .just(.updateHolding(holding)),
+                .just(.resetAdditional)
+            ])
+            
+            // 추가 매수 관련 액션들
+        case let .updateAdditionalPrice(price):
+            var additional = currentState.additional
+            additional.averagePrice = price
+            
+            // 평단가가 nil이면 모든 값 초기화
+            if price == nil {
+                additional.quantity = nil
+                additional.totalPrice = nil
+                return calculateFinalIfPossible(additional: additional)
+            }
+            
+            // 평단가가 입력되고 수량이 있으면 총액 계산
+            if let p = price, let q = additional.quantity {
+                return calculator.calculateTotalPrice(averagePrice: p, quantity: q)
+                    .flatMap { total -> Observable<Mutation> in
+                        additional.totalPrice = total
+                        return self.calculateFinalIfPossible(additional: additional)
+                    }
+            }
+            // 평단가가 입력되고 총액이 있으면 수량 계산
+            else if let p = price, let t = additional.totalPrice {
+                return calculator.calculateQuantity(averagePrice: p, totalPrice: t)
+                    .flatMap { quantity -> Observable<Mutation> in
+                        additional.quantity = quantity
+                        return self.calculateFinalIfPossible(additional: additional)
+                    }
+            }
+            
+            return calculateFinalIfPossible(additional: additional)
+            
+        case let .updateAdditionalQuantity(quantity):
+            var additional = currentState.additional
+            additional.quantity = quantity
+            
+            // 수량이 nil이면 총액 초기화
+            if quantity == nil {
+                additional.totalPrice = nil
+                return calculateFinalIfPossible(additional: additional)
+            }
+            
+            
+            // 수량이 입력되고 평단가가 있으면 총액 계산
+            if let p = additional.averagePrice, let q = quantity {
+                return calculator.calculateTotalPrice(averagePrice: p, quantity: q)
+                    .flatMap { total -> Observable<Mutation> in
+                        additional.totalPrice = total
+                        return self.calculateFinalIfPossible(additional: additional)
+                    }
+            }
+            
+            return calculateFinalIfPossible(additional: additional)
+            
+        case let .updateAdditionalTotal(total):
+            var additional = currentState.additional
+            additional.totalPrice = total
+            
+            // 총액이 nil이면 수량 초기화
+            if total == nil {
+                additional.quantity = nil
+                return calculateFinalIfPossible(additional: additional)
+            }
+            
+            // 총액이 입력되고 평단가가 있으면 수량 계산
+            if let t = total, let p = additional.averagePrice {
+                return calculator.calculateQuantity(averagePrice: p, totalPrice: t)
+                    .flatMap { quantity -> Observable<Mutation> in
+                        additional.quantity = quantity
+                        return self.calculateFinalIfPossible(additional: additional)
+                    }
+            }
+            
+            return calculateFinalIfPossible(additional: additional)
             
         case let .setInitialStock(stock):
             let holding = StockInfo(
@@ -95,27 +236,57 @@ public final class AdditionalPurchaseReactor: Reactor {
                 totalPrice: stock.totalPrice
             )
             
-            return .just(
-                .updateValues(
-                    holding: holding,
-                    additional: StockInfo(),
-                    final: nil
-                )
-            )
+            return .just(.updateHolding(holding))
         }
+    }
+    
+    private func calculateFinalIfPossible(additional: StockInfo) -> Observable<Mutation> {
+        let mutations: [Observable<Mutation>] = [.just(.updateAdditional(additional))]
+        
+        if let hp = currentState.holding.averagePrice,
+           let hq = currentState.holding.quantity,
+           let ap = additional.averagePrice,
+           let aq = additional.quantity {
+            
+            return .concat(mutations + [
+                calculator.calculateFinal(
+                    holdingAveragePrice: hp,
+                    holdingQuantity: hq,
+                    additionalAveragePrice: ap,
+                    additionalQuantity: aq
+                )
+                .map { finalResult in
+                    .updateFinal(StockInfo(
+                        averagePrice: finalResult.averagePrice,
+                        quantity: finalResult.quantity,
+                        totalPrice: finalResult.totalPrice
+                    ))
+                }
+                    .catch { error in
+                        // 에러 처리 로직 추가
+                        return .just(.updateFinal(nil))
+                    }
+            ])
+        }
+        
+        return .concat(mutations + [.just(.updateFinal(nil))])
     }
     
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         
         switch mutation {
-        case let .updateValues(holding, additional, final):
+        case let .updateHolding(holding):
             newState.holding = holding
+        case let .updateAdditional(additional):
             newState.additional = additional
+        case let .updateFinal(final):
             newState.final = final
+        case .resetAdditional:
+            newState.additional = StockInfo()
+            newState.final = nil
         }
         
         return newState
     }
-    
 }

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseReactor.swift
@@ -27,16 +27,16 @@ public final class AdditionalPurchaseReactor: Reactor {
     }
     
     public enum Mutation {
-        case updateHolding(StockInfo)
-        case updateAdditional(StockInfo)
-        case updateFinal(StockInfo?)
+        case updateHolding(StockInfoState)
+        case updateAdditional(StockInfoState)
+        case updateFinal(StockInfoState?)
         case resetAdditional
     }
     
     public struct State {
-        var holding: StockInfo
-        var additional: StockInfo
-        var final: StockInfo?
+        var holding: StockInfoState
+        var additional: StockInfoState
+        var final: StockInfoState?
     }
     
     public let initialState: State
@@ -44,8 +44,8 @@ public final class AdditionalPurchaseReactor: Reactor {
     
     public init(calculator: StockCalculatorUseCase) {
         self.initialState = State(
-            holding: StockInfo(),
-            additional: StockInfo(),
+            holding: StockInfoState(),
+            additional: StockInfoState(),
             final: nil
         )
         self.calculator = calculator
@@ -230,7 +230,7 @@ public final class AdditionalPurchaseReactor: Reactor {
             return calculateFinalIfPossible(additional: additional)
             
         case let .setInitialStock(stock):
-            let holding = StockInfo(
+            let holding = StockInfoState(
                 averagePrice: stock.averagePrice,
                 quantity: stock.quantity,
                 totalPrice: stock.totalPrice
@@ -240,7 +240,7 @@ public final class AdditionalPurchaseReactor: Reactor {
         }
     }
     
-    private func calculateFinalIfPossible(additional: StockInfo) -> Observable<Mutation> {
+    private func calculateFinalIfPossible(additional: StockInfoState) -> Observable<Mutation> {
         let mutations: [Observable<Mutation>] = [.just(.updateAdditional(additional))]
         
         if let hp = currentState.holding.averagePrice,
@@ -256,7 +256,7 @@ public final class AdditionalPurchaseReactor: Reactor {
                     additionalQuantity: aq
                 )
                 .map { finalResult in
-                    .updateFinal(StockInfo(
+                    .updateFinal(StockInfoState(
                         averagePrice: finalResult.averagePrice,
                         quantity: finalResult.quantity,
                         totalPrice: finalResult.totalPrice
@@ -283,7 +283,7 @@ public final class AdditionalPurchaseReactor: Reactor {
         case let .updateFinal(final):
             newState.final = final
         case .resetAdditional:
-            newState.additional = StockInfo()
+            newState.additional = StockInfoState()
             newState.final = nil
         }
         

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseViewController.swift
@@ -95,29 +95,67 @@ extension AdditionalPurchaseViewController: ReactorView {
     }
     
     private func bindInput(reactor: AdditionalPurchaseReactor) {
-        let quantityBasedAction = Observable.combineLatest(
-            holdingStockView.averagePriceObservable,
-            holdingStockView.quantityObservable,
-            additionalStockView.averagePriceObservable,
-            additionalStockView.quantityObservable
-        )
-        .map { holdingPrice, holdingQty, additionalPrice, additionalQty in
-            // 전처리
-            let cleanHoldingPrice = holdingPrice?.replacingOccurrences(of: ",", with: "")
-            let cleanHoldingQty = holdingQty?.replacingOccurrences(of: ",", with: "")
-            let cleanAdditionalPrice = additionalPrice?.replacingOccurrences(of: ",", with: "")
-            let cleanAdditionalQty = additionalQty?.replacingOccurrences(of: ",", with: "")
-            
-            // 모든 값을 하나의 Action으로 변환
-            return AdditionalPurchaseReactor.Action.updateBoth(
-                holdingPrice: Double(cleanHoldingPrice ?? ""),
-                holdingQuantity: Double(cleanHoldingQty ?? ""),
-                additionalPrice: Double(cleanAdditionalPrice ?? ""),
-                additionalQuantity: Double(cleanAdditionalQty ?? "")
-            )
-        }
-        .bind(to: reactor.action)
-        .disposed(by: disposeBag)
+        // 현재 보유 입력 바인딩
+        holdingStockView.averagePriceObservable
+            .map { priceStr -> Double? in
+                guard let str = priceStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateHoldingPrice($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        holdingStockView.quantityObservable
+            .map { qtyStr -> Double? in
+                guard let str = qtyStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateHoldingQuantity($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        holdingStockView.totalPriceObservable
+            .map { totalStr -> Double? in
+                guard let str = totalStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateHoldingTotal($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 추가 매수 입력 바인딩
+        additionalStockView.averagePriceObservable
+            .map { priceStr -> Double? in
+                guard let str = priceStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateAdditionalPrice($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        additionalStockView.quantityObservable
+            .map { qtyStr -> Double? in
+                guard let str = qtyStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateAdditionalQuantity($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        additionalStockView.totalPriceObservable
+            .map { totalStr -> Double? in
+                guard let str = totalStr, !str.isEmpty else { return nil }
+                let clean = str.replacingOccurrences(of: ",", with: "")
+                return Double(clean)
+            }
+            .map { Reactor.Action.updateAdditionalTotal($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     private func bindOutput(reactor: AdditionalPurchaseReactor) {

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/AdditionalPurchaseViewController.swift
@@ -38,6 +38,7 @@ public class AdditionalPurchaseViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.hideKeyboardWhenTappedAround()
         setStyle()
         setUI()
         setLayout()
@@ -94,7 +95,7 @@ extension AdditionalPurchaseViewController: ReactorView {
     }
     
     private func bindInput(reactor: AdditionalPurchaseReactor) {
-        Observable.combineLatest(
+        let quantityBasedAction = Observable.combineLatest(
             holdingStockView.averagePriceObservable,
             holdingStockView.quantityObservable,
             additionalStockView.averagePriceObservable,

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/ReusableViews/LabeledTextFieldView.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/ReusableViews/LabeledTextFieldView.swift
@@ -121,7 +121,8 @@ extension LabeledTextFieldView {
     }
     
     func setText(_ text: String?) {
-        textField.text = formatText(text)
+        let formattedText = formatText(text)
+        textField.text = formattedText
     }
     
     func setEditable(_ editable: Bool) {

--- a/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/States/StockInfoState.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/AdditionalPurchase/States/StockInfoState.swift
@@ -1,5 +1,5 @@
 //
-//  StockInfo.swift
+//  StockInfoState.swift
 //  Domain
 //
 //  Created by 조호근 on 10/16/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct StockInfo: Equatable {
+public struct StockInfoState: Equatable {
     
     public var averagePrice: Double?
     public var quantity: Double?

--- a/InvestMate/Projects/Presentation/Sources/Views/Profit/ProfitReactor.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/Profit/ProfitReactor.swift
@@ -17,11 +17,11 @@ public final class ProfitReactor: Reactor {
     }
     
     public enum Mutation {
-        case setProfitInfo(ProfitInfo)
+        case setProfitInfo(ProfitInfoState)
     }
     
     public struct State {
-        var profitInfo: ProfitInfo
+        var profitInfo: ProfitInfoState
     }
     
     public let initialState: State
@@ -29,7 +29,7 @@ public final class ProfitReactor: Reactor {
     
     public init(calculator: ProfitCalculatorUseCase) {
         self.calculator = calculator
-        self.initialState = State(profitInfo: ProfitInfo())
+        self.initialState = State(profitInfo: ProfitInfoState())
     }
     
     public func mutate(action: Action) -> Observable<Mutation> {
@@ -51,7 +51,7 @@ public final class ProfitReactor: Reactor {
                     calculator.calculateTotalAmount(price: salePrice, quantity: qty)
                 )
                 .map { profitResult, purchaseAmount, saleAmount in
-                    let profitInfo = ProfitInfo(
+                    let profitInfo = ProfitInfoState(
                         totalProfit: profitResult.totalProfit,
                         profitRate: profitResult.profitRate,
                         purchaseAmount: purchaseAmount,
@@ -62,7 +62,7 @@ public final class ProfitReactor: Reactor {
                 }
             }
             
-            return .just(.setProfitInfo(ProfitInfo()))
+            return .just(.setProfitInfo(ProfitInfoState()))
         }
     }
     

--- a/InvestMate/Projects/Presentation/Sources/Views/Profit/ProfitViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/Profit/ProfitViewController.swift
@@ -33,6 +33,7 @@ public class ProfitViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.hideKeyboardWhenTappedAround()
         setStyle()
         setUI()
         setLayout()

--- a/InvestMate/Projects/Presentation/Sources/Views/Profit/States/ProfitInfoState.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/Profit/States/ProfitInfoState.swift
@@ -1,5 +1,5 @@
 //
-//  ProfitInfo.swift
+//  ProfitInfoState.swift
 //  Domain
 //
 //  Created by 조호근 on 12/6/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ProfitInfo: Equatable {
+public struct ProfitInfoState: Equatable {
     
     public let totalProfit: Double?
     public let profitRate: Double?

--- a/InvestMate/Projects/Presentation/Sources/Views/StockManagement/CreateStock/CreateStockViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/StockManagement/CreateStock/CreateStockViewController.swift
@@ -13,6 +13,8 @@ import RxSwift
 
 final class CreateStockViewController: UIViewController {
     
+    private let mode: CreateStockReactor.Mode
+    
     public var disposeBag = DisposeBag()
     
     private let nameLabel = UILabel()
@@ -23,7 +25,8 @@ final class CreateStockViewController: UIViewController {
     private let totalPriceView = LabeledTextFieldView(title: "총 금액", placeholder: "금액")
     private let confirmButton = UIButton()
     
-    init(reactor: CreateStockReactor) {
+    init(reactor: CreateStockReactor, mode: CreateStockReactor.Mode = .create) {
+        self.mode = mode
         super.init(nibName: nil, bundle: nil)
         self.reactor = reactor
     }
@@ -38,6 +41,13 @@ final class CreateStockViewController: UIViewController {
         setStyle()
         setUI()
         setLayout()
+        configureNavigationTitle()
+        configureConfirmButton()
+        
+        if case .edit(let stock) = mode {
+            nameTextField.text = stock.name
+            reactor?.action.onNext(.setInitialStock(stock))
+        }
     }
     
     private func setStyle() {
@@ -59,17 +69,24 @@ final class CreateStockViewController: UIViewController {
         nameTextField.keyboardType = .default
         
         dividerView.configureDivider()
-        
+    }
+    
+    private func configureNavigationTitle() {
+        title = mode == .create ? "종목 추가" : "종목 수정"
+    }
+    
+    private func configureConfirmButton() {
         var config = UIButton.Configuration.filled()
         config.cornerStyle = .capsule
         config.baseForegroundColor = .white
         config.baseBackgroundColor = .black
         
+        let buttonTitle = mode == .create ? "추가하기" : "수정하기"
         let attributes =  AttributeContainer([
             .font: UIFont.systemFont(ofSize: 16, weight: .semibold)
         ])
         
-        config.attributedTitle = AttributedString("추가하기", attributes: attributes)
+        config.attributedTitle = AttributedString(buttonTitle, attributes: attributes)
         confirmButton.configuration = config
     }
     

--- a/InvestMate/Projects/Presentation/Sources/Views/StockManagement/CreateStock/CreateStockViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/StockManagement/CreateStock/CreateStockViewController.swift
@@ -38,6 +38,7 @@ final class CreateStockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.hideKeyboardWhenTappedAround()
         setStyle()
         setUI()
         setLayout()

--- a/InvestMate/Projects/Presentation/Sources/Views/StockManagement/ReusableViews/Cell/StockCell.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/StockManagement/ReusableViews/Cell/StockCell.swift
@@ -92,13 +92,13 @@ public final class StockCell: UITableViewCell {
         ])
         
         NSLayoutConstraint.activate([
-            stockNameLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
-            stockNameLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            
-            menuButton.centerYAnchor.constraint(equalTo: stockNameLabel.centerYAnchor),
+            menuButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
             menuButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
             menuButton.widthAnchor.constraint(equalToConstant: 44),
             menuButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            stockNameLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            stockNameLabel.centerYAnchor.constraint(equalTo: menuButton.centerYAnchor),
             
             dividerView.topAnchor.constraint(equalTo: menuButton.bottomAnchor, constant: 8),
             dividerView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),

--- a/InvestMate/Projects/Presentation/Sources/Views/StockManagement/StockList/StockListViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/StockManagement/StockList/StockListViewController.swift
@@ -175,11 +175,12 @@ extension StockListViewController: StockListRefreshDelegate {
         let createStockReactor = CreateStockReactor(
             stockManager: reactor.getStockManager(),
             calculator: calculator,
-            mode: stock.map { .edit($0) } ?? .create,
+            mode: mode,
             refreshDelegate: self
         )
         
-        let createStockVC = CreateStockViewController(reactor: createStockReactor)
+        let createStockVC = CreateStockViewController(reactor: createStockReactor,
+                                                      mode: mode)
         navigationController?.pushViewController(createStockVC, animated: true)
     }
     

--- a/InvestMate/Projects/Presentation/Sources/Views/StockManagement/StockList/StockListViewController.swift
+++ b/InvestMate/Projects/Presentation/Sources/Views/StockManagement/StockList/StockListViewController.swift
@@ -80,7 +80,7 @@ public final class StockListViewController: UIViewController {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         let additionalPurchase = UIAlertAction(title: "추가 매수", style: .default) { [weak self] _ in
-            self?.navigateToAdditionalPurchase()
+            self?.navigateToAdditionalPurchase(with: stock)
         }
         
         let edit = UIAlertAction(title: "수정", style: .default) { [weak self] _ in
@@ -96,12 +96,6 @@ public final class StockListViewController: UIViewController {
         [ edit, additionalPurchase, delete, cancel ].forEach { alert.addAction($0) }
         
         present(alert, animated: true)
-    }
-    
-    private func navigateToAdditionalPurchase() {
-        if let tabBarController = tabBarController {
-            tabBarController.selectedIndex = 0
-        }
     }
 
 }
@@ -182,6 +176,17 @@ extension StockListViewController: StockListRefreshDelegate {
         let createStockVC = CreateStockViewController(reactor: createStockReactor,
                                                       mode: mode)
         navigationController?.pushViewController(createStockVC, animated: true)
+    }
+    
+    private func navigateToAdditionalPurchase(with stock: Stock) {
+        if let tabBarController = tabBarController,
+           let navigationController = tabBarController.viewControllers?[0] as? UINavigationController,
+           let additionalPurchaseVC = navigationController.viewControllers.first as? AdditionalPurchaseViewController {
+            
+            additionalPurchaseVC.reactor?.action.onNext(.setInitialStock(stock))
+            
+            tabBarController.selectedIndex = 0
+        }
     }
     
 }


### PR DESCRIPTION
## 📌 작업 주제
- [ ] UI 추가
- [x] 기능 추가
- [x] 리팩토링
- [x] 버그 수정

## 📋 작업 내용
- [x] 종목 수정 기능 구현
- [x] 종목셀의 추가매수 메뉴 선택시, 추가매수 뷰로 이동하여 바로 추가매수 할 수 있도록 구현

# 고민과 해결
### 1. 계산할 때 여러 케이스를 고려하지 못한 문제를 경험
1. 값이 nil이 되는 경우에 대한 처리가 미흡하였음
- 평단가가 nil이면 수량, 총액 상태 유지한다.
- 수량이 nil이면 총액 상태 유지한다.
- 총액이 nil이면 수량 상태 유지한다.

2. 불완전한 상태 관리
- 세 값(평단가/수량/총액)의 연관관계를 확실하게 관리하지 못하였음
- 하나의 값이 없어질 때 연관된 값들도 초기화되어야 하는데 누락되어있는 문제를 발견

### 1. 개선된 점
1. 명확하게 상태 관리함
- nil 케이스를 먼저 처리하여 연관 값들 초기화 시킴
- 값이 있는 경우에 모든 처리 분리하고자 하였음

2. 데이터 일관성을 확보
- 평단가 없다면? -> 수량, 총액도 없다.
- 수량 없다면? -> 총액 없다.
- 총액 없다면? -> 수량 없다.

[ 결론 ]
어떤 값이 없어질 때, 연관된 값들도 함께 초기화되어 사용자가 예상할 수 있도록 개선함.
다음부터는 명확한 조건문과 데이터 일관성을 고려할 수 있도록 신경쓰도록 하자 ^_^

### 2. StockInfo의 불변성에 대한 고민과 개선
상태 관리의 편의성이 let으로 인한 불변성으로 이점보다 크다고 판단하여 var사용으로 개선함.
1. Reactor 패턴에서 상태 업데이트가 빈번함.
프로퍼티 개별 수정이 필요한 상황이 많이 있는데 이때 불변성으로 인한 인스턴스를 생성하면 코드가 너무 길어져서, 가독성이 떨어질 것으로 예상되는 우려

2. 상태 변경 로직이 더 직관적으로 다가옴
가독성 향상

[결론]
엔티티와 뷰의 상태를 관리하기 위한 모델을 혼동하여,
뷰 상태 모델을 불변성 지켜야한다는 생각이 강하게 들어서 생긴 문제였다고 생각


## 💻 결과
| 결과  |
| :--: |
| <img src = "https://github.com/user-attachments/assets/583a02e5-ffae-4eb1-b253-c4827787fd23" width ="250">| 



관련이슈: KAN-24